### PR TITLE
feat: print HTTP response for ruby

### DIFF
--- a/sdb-shim/src/https_instrument.c
+++ b/sdb-shim/src/https_instrument.c
@@ -6,7 +6,7 @@
 #include "openssl/ssl.h"
 #include "sys/socket.h"
 
-#define CHUNK 16384
+#define MAX_HTTP_FD_COUNT 100000
 
 // compile:
 //  gcc -I/opt/homebrew/Cellar/openssl@1.1/1.1.1w/include -L/opt/homebrew/Cellar/openssl@1.1/1.1.1w/lib -lssl -lcrypto -shared -fPIC -o https_instrument.dylib src/https_instrument.c -lz
@@ -15,19 +15,57 @@ struct __osx_interpose {
     const void* orig_func;
 };
 
-static int Real__SSL_read (void *ssl, void *buf, int num) { return SSL_read (ssl, buf, num); }
-extern int __interpose_SSL_read (void *ssl, void *buf, int num);
+int *HTTP_FDS = NULL;
+
+int initialize_http_fds_once() {
+    if (HTTP_FDS == NULL) {
+        // when this line has been executed concurrently, some memory could be wated
+        HTTP_FDS = (int *)malloc(MAX_HTTP_FD_COUNT * sizeof(int));
+
+        if (HTTP_FDS == NULL) {
+            fprintf(stderr, "Memory allocation failed\n");
+            return -1;
+        }
+
+        for (int i = 0; i < MAX_HTTP_FD_COUNT; i++) {
+            HTTP_FDS[i] = -1;
+        }
+    }
+
+    return 0;
+}
+
+// for SSL_read
+static int Real__SSL_read(void *ssl, void *buf, int num) { return SSL_read (ssl, buf, num); }
+extern int __interpose_SSL_read(void *ssl, void *buf, int num);
 
 static const struct __osx_interpose __osx_interpose_SSL_read __attribute__((used, section("__DATA, __interpose"))) =
   { (const void*)((uintptr_t)(&(__interpose_SSL_read))),
     (const void*)((uintptr_t)(&(SSL_read))) };
 
-static ssize_t Real__read (int socket, void *buffer, size_t length) { return read(socket, buffer, length); }
-extern ssize_t __interpose_read (int, void *, size_t);
+// for read
+static ssize_t Real__read(int socket, void *buffer, size_t length) { return read(socket, buffer, length); }
+extern ssize_t __interpose_read(int, void *, size_t);
 
 static const struct __osx_interpose __osx_interpose_read __attribute__((used, section("__DATA, __interpose"))) =
   { (const void*)((uintptr_t)(&(__interpose_read))),
     (const void*)((uintptr_t)(&(read))) };
+
+// socket
+static int Real__socket(int domain, int type, int protocol) { return socket(domain, type, protocol); }
+extern int __interpose_socket(int domain, int type, int protocol);
+
+static const struct __osx_interpose __osx_interpose_socket __attribute__((used, section("__DATA, __interpose"))) =
+  { (const void*)((uintptr_t)(&(__interpose_socket))),
+    (const void*)((uintptr_t)(&(socket))) };
+
+// close
+static int Real__close(int fd) { return close(fd); }
+extern int __interpose_close(int fd);
+
+static const struct __osx_interpose __osx_interpose_close __attribute__((used, section("__DATA, __interpose"))) =
+  { (const void*)((uintptr_t)(&(__interpose_close))),
+    (const void*)((uintptr_t)(&(close))) };
 
 const unsigned char *skip_crlf(const unsigned char *body) {
     assert(strncmp((const char *)body, "\r\n", 2) == 0);
@@ -141,7 +179,7 @@ int decompress_gzip(const unsigned char *compressed_data, size_t compressed_data
 
 void print_buffer(const char* buff, size_t len) {
     for (size_t i = 0; i < len; i++) {
-        fprintf(__stderrp, "%c", buff[i]);
+        printf("%c", buff[i]);
     }
 }
 
@@ -183,10 +221,31 @@ extern int __interpose_SSL_read (void *ssl, void *buf, int num) {
 
 extern ssize_t __interpose_read(int socket, void *buffer, size_t length) {
     ssize_t ret = Real__read(socket, buffer, length);
-    if (ret > 0) {
+    if (ret > 0 && HTTP_FDS != NULL && HTTP_FDS[socket] == 1) {
         print_buffer(buffer, ret);
+        printf("\n\n");
     }
 
-    // printf("read socket=%d, %zu, rt=%zd\n", socket, length, ret);
+    return ret;
+}
+
+extern int __interpose_socket(int domain, int type, int protocol) {
+    int ret = Real__socket(domain, type, protocol);
+
+    // todo: handle concurrency issues
+    if (domain == AF_INET || domain == AF_INET6) {
+        initialize_http_fds_once();
+        HTTP_FDS[ret] = 1;
+    }
+
+    return ret;
+}
+
+extern int __interpose_close(int fd) {
+    int ret = Real__close(fd);
+    // todo: handle concurrency issues
+    if (ret == 0 && HTTP_FDS != NULL && fd > 0) {
+        HTTP_FDS[fd] = -1;
+    }
     return ret;
 }


### PR DESCRIPTION
Print HTTP response for Ruby.

Normally, people can use tcpdump to inspect HTTP response, but some machines do not have root permission :joy:.