### PR TITLE
feat: symbolize c functions

### DIFF
--- a/ext/sdb/src/lib.rs
+++ b/ext/sdb/src/lib.rs
@@ -157,13 +157,17 @@ unsafe extern "C" fn record_thread_frames(
 
     for item in slice {
         let iseq: &rb_iseq_struct = &*item.iseq;
-        // iseq is 0 when it is a cframe, see vm_call_cfunc_with_frame.
-        // Ruby saves rb_callable_method_entry_t on its stack through sp pointer and we can get relative info through the rb_callable_method_entry_t.
-        // But for getting it, we need to make sure the sp doesn't change and the rb_callable_method_entry_t hasn't been freed.
-        // It may cause too much troubles, so we consider how to read cframe in the future.
+
         let iseq_addr = iseq as *const _ as u64;
 
-        iseq_logger.push(iseq_addr);
+        // iseq is 0 when it is a cframe, see vm_call_cfunc_with_frame.
+        // Ruby saves rb_callable_method_entry_t on its stack through sp pointer and we can get relative info through the rb_callable_method_entry_t.
+        if iseq_addr == 0 {
+            let cref_or_me = *item.sp.offset(-3);
+            iseq_logger.push(cref_or_me as u64);
+        } else {
+            iseq_logger.push(iseq_addr);
+        }
     }
 
     iseq_logger.push_seperator();

--- a/symbolizer/symbolizer.c
+++ b/symbolizer/symbolizer.c
@@ -232,3 +232,21 @@ int rb_define_method_instrument(struct pt_regs *ctx) {
 
     return 0;
 }
+
+
+int rb_method_entry_make_return_instrument(struct pt_regs *ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u64 pid = pid_tgid >> 32;
+    u64 tid = pid_tgid & 0xFFFFFFFF;
+
+    struct event_t event = {};
+    event.pid = pid;
+    event.tid = tid;
+    event.ts = bpf_ktime_get_ns();
+    event.iseq_addr = PT_REGS_RC(ctx);
+
+    event.debug = 4;
+    events.perf_submit(ctx, &event, sizeof(event));
+
+    return 0;
+}

--- a/symbolizer/symbolizer.c
+++ b/symbolizer/symbolizer.c
@@ -29,50 +29,6 @@ struct RString {
     } as;
 };
 
-typedef uint32_t attr_index_t;
-
-struct rb_id_table {};
-struct rb_subclass_entry {};
-struct RClass {};
-typedef VALUE (*rb_alloc_func_t)(VALUE klass);
-typedef uint32_t attr_index_t;
-
-struct rb_classext_struct {
-    VALUE *iv_ptr;
-    struct rb_id_table *const_tbl;
-    struct rb_id_table *callable_m_tbl;
-    struct rb_id_table *cc_tbl; /* ID -> [[ci1, cc1], [ci2, cc2] ...] */
-    struct rb_id_table *cvc_tbl;
-    size_t superclass_depth;
-    VALUE *superclasses;
-    struct rb_subclass_entry *subclasses;
-    struct rb_subclass_entry *subclass_entry;
-    struct rb_subclass_entry *module_subclass_entry;
-    const VALUE origin_;
-    const VALUE refined_class;
-    union {
-        struct {
-            rb_alloc_func_t allocator;
-        } class;
-        struct {
-            VALUE attached_object;
-        } singleton_class;
-    } as;
-    const VALUE includer;
-    attr_index_t max_iv_count;
-    unsigned char variation_count;
-    bool permanent_classpath : 1;
-    bool cloned : 1;
-    VALUE classpath;
-};
-
-typedef struct rb_classext_struct rb_classext_t;
-
-struct RClass_and_rb_classext_t {
-    struct RClass rclass;
-    rb_classext_t classext;
-};
-
 typedef struct rb_iseq_location_struct {
     VALUE pathobj;      /* String (path) or Array [path, realpath]. Frozen. */
     VALUE base_label;   /* String */
@@ -143,8 +99,6 @@ struct rb_iseq_struct {
     struct rb_iseq_constant_body *body;
     // ...
 };
-
-#define RCLASS_EXT(c) (&((struct RClass_and_rb_classext_t*)(c))->classext)
 
 BPF_PERF_OUTPUT(events);
 
@@ -266,21 +220,19 @@ int rb_define_method_instrument(struct pt_regs *ctx) {
     u64 tid = pid_tgid & 0xFFFFFFFF;
 
     const char *name = (const char *)PT_REGS_PARM2(ctx);
-    VALUE klass = (VALUE)PT_REGS_PARM1(ctx);
-    struct RString *classpth;
-    bpf_probe_read(&classpth, sizeof(classpth), &(RCLASS_EXT(klass)->classpath));
 
     struct event_t event = {};
     event.pid = pid;
     event.tid = tid;
     event.ts = bpf_ktime_get_ns();
     bpf_probe_read_user(&event.name, sizeof(event.name), name);
-    read_rstring(classpth, event.path);
+    event.iseq_addr = PT_REGS_PARM3(ctx);
     event.type = 3;
     events.perf_submit(ctx, &event, sizeof(event));
 
     return 0;
 }
+
 
 int rb_method_entry_make_return_instrument(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();

--- a/symbolizer/symbolizer.py
+++ b/symbolizer/symbolizer.py
@@ -35,7 +35,7 @@ class Event(ctypes.Structure):
         ("name", ctypes.c_char * MAX_STR_LENGTH),
         ("path", ctypes.c_char * MAX_STR_LENGTH),
         ("iseq_addr", ctypes.c_uint64),
-        ("debug", ctypes.c_uint32),
+        ("type", ctypes.c_uint32),
     ]
 
     def to_dict(self):
@@ -47,7 +47,7 @@ class Event(ctypes.Structure):
             "name": self.name.decode('utf-8').rstrip('\x00'),
             "path": self.path.decode('utf-8').rstrip('\x00'),
             "iseq_addr": self.iseq_addr,
-            "debug": self.debug,
+            "type": self.type,
         }
 
         return data

--- a/symbolizer/symbolizer.py
+++ b/symbolizer/symbolizer.py
@@ -20,6 +20,8 @@ b.attach_uretprobe(name=binary_path, sym="rb_iseq_new_with_callback", fn_name="r
 # bootsnap loaded iseqs
 b.attach_uretprobe(name=binary_path, sym="ibf_load_iseq", fn_name="ibf_load_iseq_return_instrument")
 
+# c function
+b.attach_uprobe(name=binary_path, sym="rb_define_method", fn_name="rb_define_method_instrument")
 
 # TODO: capture c functions
 class Event(ctypes.Structure):

--- a/symbolizer/symbolizer.py
+++ b/symbolizer/symbolizer.py
@@ -24,6 +24,8 @@ b.attach_uretprobe(name=binary_path, sym="ibf_load_iseq", fn_name="ibf_load_iseq
 b.attach_uprobe(name=binary_path, sym="rb_define_method", fn_name="rb_define_method_instrument")
 b.attach_uretprobe(name=binary_path, sym="rb_method_entry_make", fn_name="rb_method_entry_make_return_instrument")
 
+b.attach_uprobe(name=binary_path, sym="rb_define_module", fn_name="rb_define_module_instrument")
+b.attach_uretprobe(name=binary_path, sym="rb_define_module", fn_name="rb_define_module_return_instrument")
 
 # TODO: capture c functions
 class Event(ctypes.Structure):

--- a/symbolizer/symbolizer.py
+++ b/symbolizer/symbolizer.py
@@ -22,6 +22,8 @@ b.attach_uretprobe(name=binary_path, sym="ibf_load_iseq", fn_name="ibf_load_iseq
 
 # c function
 b.attach_uprobe(name=binary_path, sym="rb_define_method", fn_name="rb_define_method_instrument")
+b.attach_uretprobe(name=binary_path, sym="rb_method_entry_make", fn_name="rb_method_entry_make_return_instrument")
+
 
 # TODO: capture c functions
 class Event(ctypes.Structure):


### PR DESCRIPTION
This pr doesn't capture all c functions labels. But it reduced the no-symbol rate from 12% to %6

TODO: handle the singleton method.