### PR TITLE
feat: handle thread finished execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,12 +556,14 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "fast_log",
+ "lazy_static",
  "libc",
  "log",
  "rb-sys",
  "rbspy-ruby-structs",
  "serde",
  "serde_json",
+ "spin",
 ]
 
 [[package]]

--- a/ext/sdb/Cargo.toml
+++ b/ext/sdb/Cargo.toml
@@ -12,9 +12,11 @@ crate-type = ["cdylib"]
 [dependencies]
 chrono = "0.4.38"
 fast_log = "1.7.3"
+lazy_static = "1.5.0"
 libc = "0.2.155"
 log = "0.4.22"
 rb-sys = { version = "0.9.99", features = ["stable-api"]}
 rbspy-ruby-structs = "0.24.0"
 serde = { version = "1.0.205", features = ["derive"] }
 serde_json = "1.0.122"
+spin = "0.9.8"

--- a/ext/sdb/src/lib.rs
+++ b/ext/sdb/src/lib.rs
@@ -24,6 +24,17 @@ extern "C" fn Init_sdb() {
         >(rb_pull);
         rb_define_singleton_method(module, "pull\0".as_ptr() as _, Some(pull_callback), 2);
 
+        let delete_inactive_thread_callback = std::mem::transmute::<
+            unsafe extern "C" fn(VALUE, VALUE, VALUE) -> VALUE,
+            unsafe extern "C" fn() -> VALUE,
+        >(rb_delete_inactive_thread);
+        rb_define_singleton_method(
+            module,
+            "delete_inactive_thread\0".as_ptr() as _,
+            Some(delete_inactive_thread_callback),
+            2,
+        );
+
         let set_trace_id_callback = std::mem::transmute::<
             unsafe extern "C" fn(VALUE, VALUE, VALUE) -> VALUE,
             unsafe extern "C" fn() -> VALUE,

--- a/ext/sdb/src/stack_scanner.rs
+++ b/ext/sdb/src/stack_scanner.rs
@@ -5,7 +5,7 @@ use crate::trace_id::*;
 use chrono::Utc;
 use libc::c_void;
 use rb_sys::{
-    rb_int2inum, rb_num2dbl, rb_thread_call_without_gvl, Qtrue, RTypedData, RARRAY_LEN, VALUE,
+    rb_int2inum, rb_num2dbl, rb_thread_call_without_gvl, Qtrue, Qnil, RTypedData, RARRAY_LEN, VALUE,
 };
 use rbspy_ruby_structs::ruby_3_1_5::{rb_control_frame_struct, rb_iseq_struct, rb_thread_t};
 
@@ -14,9 +14,20 @@ use std::slice;
 use std::time::Duration;
 use std::{ptr, thread};
 
+use lazy_static::lazy_static;
+use spin::Mutex;
+
+lazy_static! {
+    // It should be fine to use the spin lock, as the scanner acquires and releases this lock very quickly.
+    // When a Ruby application holds this lock and is suspended, the scanner will be blocked and busy waiting, it depends on the Ruby thread scheduler, I am not sure if this could happen.
+    // The raw lock needs to work with Ruby VM, but in scanner, it dosn't have GVL, it may cause problems.
+    // Even spin lock is not pefect consider that the thread could be suspended by Ruby VM, but it could work.
+    static ref THREADS_TO_SCAN_LOCK: Mutex<i32> = Mutex::new(0);
+}
+
 struct PullData {
     current_thread: VALUE,
-    threads: VALUE,
+    threads_to_scan: VALUE,
     stop: bool,
     sleep_millis: u32,
 }
@@ -75,7 +86,7 @@ unsafe extern "C" fn do_pull(data: *mut c_void) -> *mut c_void {
 
     let data: &mut PullData = ptr_to_struct(data);
 
-    let threads_count = RARRAY_LEN(data.threads) as isize;
+    let threads_count = RARRAY_LEN(data.threads_to_scan) as isize;
 
     let trace_table = get_trace_id_table();
     let mut i = 0;
@@ -84,7 +95,7 @@ unsafe extern "C" fn do_pull(data: *mut c_void) -> *mut c_void {
     // program can insert before init which may cause issuess ...
     while i < threads_count {
         let argv = &[rb_int2inum(i)];
-        let thread = rb_sys::rb_ary_aref(1, arvg_to_ptr(argv), data.threads);
+        let thread = rb_sys::rb_ary_aref(1, arvg_to_ptr(argv), data.threads_to_scan);
 
         trace_table.entry(thread).or_insert(0);
 
@@ -100,9 +111,11 @@ unsafe extern "C" fn do_pull(data: *mut c_void) -> *mut c_void {
         let mut i: isize = 0;
         while i < threads_count {
             // TODO: covert ruby array to rust array before loop, it could increase performance slightly
-            let thread = rb_sys::rb_ary_entry(data.threads, i as i64);
-            if thread != data.current_thread {
+            let thread = rb_sys::rb_ary_entry(data.threads_to_scan, i as i64);
+            if thread != data.current_thread && thread != Qnil.into() {
+                let lock = THREADS_TO_SCAN_LOCK.lock();
                 record_thread_frames(thread, trace_table, &mut iseq_logger);
+                drop(lock);
             }
 
             i += 1;
@@ -116,7 +129,7 @@ unsafe extern "C" fn do_pull(data: *mut c_void) -> *mut c_void {
 
 pub(crate) unsafe extern "C" fn rb_pull(
     module: VALUE,
-    threads: VALUE,
+    threads_to_scan: VALUE,
     sleep_seconds: VALUE,
 ) -> VALUE {
     let argv: &[VALUE; 0] = &[];
@@ -124,7 +137,7 @@ pub(crate) unsafe extern "C" fn rb_pull(
 
     let mut data = PullData {
         current_thread: current_thread,
-        threads: threads,
+        threads_to_scan,
         stop: false,
         sleep_millis: (rb_num2dbl(sleep_seconds) * 1000.0) as u32,
     };
@@ -136,6 +149,18 @@ pub(crate) unsafe extern "C" fn rb_pull(
         Some(ubf_do_pull),
         struct_to_ptr(&mut data),
     );
+
+    Qtrue as VALUE
+}
+
+pub(crate) unsafe extern "C" fn rb_delete_inactive_thread(
+    _module: VALUE,
+    threads_to_scan: VALUE,
+    thread: VALUE,
+) -> VALUE {
+    let lock = THREADS_TO_SCAN_LOCK.lock();
+    call_method(threads_to_scan, "delete", 1, &[thread]);
+    drop(lock);
 
     Qtrue as VALUE
 }

--- a/lib/sdb.rb
+++ b/lib/sdb.rb
@@ -6,6 +6,23 @@ require_relative "sdb/puma_patch"
 require_relative "sdb/thread_patch"
 
 module Sdb
+  module ThreadInitializePatch
+    def initialize(*args, &block)
+      old_block = block
+
+      block = ->() do
+        puts "before thread start"
+        result = old_block.call(*args)
+        puts "before thread finish"
+        result
+      end
+
+      super(&block)
+    end
+  end
+
+  Thread.prepend(ThreadInitializePatch)
+
   class << self
     def fetch_puma_threads
       # keep a reference as puller runs without gvl

--- a/lib/sdb/thread_patch.rb
+++ b/lib/sdb/thread_patch.rb
@@ -5,8 +5,9 @@ module Sdb
     end
 
     module Initialize
-      def initialize(*args)
+      def initialize(*args, &block)
         parent = Thread.current
+
         child = super
         puts "[#{Process.pid}] parent_id=#{parent.native_thread_id}, child_id=#{child.native_thread_id}, caller=#{caller[0]}"
         child

--- a/scripts/handle_thread_reclaim.rb
+++ b/scripts/handle_thread_reclaim.rb
@@ -1,0 +1,14 @@
+require 'byebug'
+require 'sdb'
+
+10.times do
+  Thread.new {
+    sleep rand(10)
+  }
+end
+
+thread = Thread.new {
+  Sdb.scan_all_threads
+}
+
+thread.join


### PR DESCRIPTION
Before a thread finishes its execution, we need to remove it from the threads scanning list.

So wrap a block to the Ruby thread block for adding hooks.
