### PR TITLE
feat: make trace-id table safe

### DIFF
--- a/ext/sdb/src/trace_id.rs
+++ b/ext/sdb/src/trace_id.rs
@@ -1,4 +1,4 @@
-use rb_sys::{rb_num2ulong, Qtrue, VALUE};
+use rb_sys::{rb_num2ulong, Qfalse, Qtrue, VALUE};
 use std::collections::HashMap;
 use std::ptr;
 
@@ -13,16 +13,35 @@ fn init_trace_id_table() {
     }
 }
 
-// The trace_id is set by applications threads and read by stack puller thread.
-// They should not block each other's execution.
-// Correctness is not our first consideration, we only require hardware can access this atomically.
+// Safety Argument:
+
+// If a hash-map has a fixed size, it's relatively "safe" to access it without a lock.
+// Only during rehashing, it needs to avoid all reads at the same time.
+
+// When the Ruby VM creates a new thread, SDB inserts a dummy value into the trace-id table.
+// At this moment, it already acquired the THREADS_TO_SCAN_LOCK, which blocks the scanner thread -- the only reader(see rb_add_thread_to_scan method).
+// This guarantees that no reader is accessing this table during rehashing.
+
+// Additionally, when SDB needs to read this, it uses a memory barrier for getting the newest value.
+// Therefore, I believe this implementation is safe even though it has a lot of "unsafe" code. Yes, it is tricky.
+#[inline]
 pub fn get_trace_id_table() -> &'static mut HashMap<u64, u64> {
     unsafe {
         if TRACE_TABLE.is_null() {
             init_trace_id_table();
         }
+
         &mut *TRACE_TABLE
     }
+}
+
+#[inline]
+pub(crate) unsafe extern "C" fn set_trace_id(thread: VALUE, trace_id: u64) -> bool {
+    let trace_table = get_trace_id_table();
+
+    trace_table.insert(thread, trace_id);
+
+    true
 }
 
 pub(crate) unsafe extern "C" fn rb_set_trace_id(
@@ -30,9 +49,9 @@ pub(crate) unsafe extern "C" fn rb_set_trace_id(
     thread: VALUE,
     trace_id: VALUE,
 ) -> VALUE {
-    let trace_table = get_trace_id_table();
-
-    trace_table.insert(thread, rb_num2ulong(trace_id));
-
-    Qtrue as VALUE
+    if set_trace_id(thread, rb_num2ulong(trace_id)) {
+        Qtrue as VALUE
+    } else {
+        Qfalse as VALUE
+    }
 }


### PR DESCRIPTION
The trace-id is a hash table that can be inserted in a Ruby thread and read in the scanner thread.

If we consider the hash table as a fixed-size array, it's safe to access it without a lock if we use a memory barrier and its value is u64.

The next step is guaranteeing that no readers access the data during rehashing.

SDB maintains a threads list that is protected by a lock. When a thread is created, SDB acquires this lock and updates the list. When the scanner needs to scan a thread's stack, it acquires the lock too. SDB inserts a dummy value when Ruby creates a new thread and at this point, the lock has been acquired. As the scanner has been blocked, no threads read the trace-id. Therefore, SDB guarantees no read access during rehashing.

This code is very tricky but adheres to SDB's design goal: non-blocking when feasible.