### PR TITLE
feat: safety argument and update trace-id

### DIFF
--- a/document/safety_argument.md
+++ b/document/safety_argument.md
@@ -13,7 +13,22 @@ Achieving the first design goal could solve 90% or even 99% of performance issue
 Because of these design goals, the Rust safety mechanism is not enough. Additionally, it seems that there is no good answer on how to use safe code when using Rust in other systems. For example, in Rust-for-Linux, comments are needed to reason about the safety of unsafe blocks[1]. Magnus[2] also depends on many `unsafe` code blocks and restricts usage, such as not allowing passing Ruby objects to the heap in Rust.
 
 ## Scanning the Ruby Stack without the GVL
-## Trace-id Hash Table
+Please check this article: https://github.com/yfractal/blog/blob/master/blog/2025-01-15-non-blocking-stack-profiler.md
+
+## The Trace-id Hash Table
+
+The trace-id hash table maintains per-thread trace-ids for SDB. Ruby threads update this hash table, and the SDB scanner thread reads the values. This means the hash table is accessed concurrently, but to fulfill the second design goal, it doesn't use locks.
+
+To use a hash table safely, we need to consider:
+
+1. Before resizing a hash table, we should have exclusive access.
+2. When querying a hash table, we should see the most recent write.
+
+When creating a new Ruby thread, a lock (`THREADS_TO_SCAN_LOCK`) is acquired for updating the threads list. While this lock is held, the scanner is blocked. During this time, a dummy trace-id is inserted for the thread into the table. Similarly, when a Ruby thread is being reclaimed, the lock is acquired, and the thread is deleted from the table. Hash resizing can only happen when a new key is added or a key is deleted. Since the lock is held during these operations, the scanner thread does not read the table, fulfilling the first consideration.
+
+For the second consideration, SDB uses atomic variables for the hash table's values with memory ordering (release order when updating and acquire order when reading).
+
+A lock (whether a mutex or spinlock) requires updating an atomic value twice -- acquiring the lock and releasing the lock at least. Making the value an atomic variable only requires one atomic update, so it could be more efficient. From an engineer's point of view, such optimization may not be worth it as it introduces complexity with little benefit. However, SDB works as an experimental project, and such an implementation is interesting and challenging.
 
 ## References
 1. An Empirical Study of Rust-for-Linux: The Success, Dissatisfaction, and Compromise

--- a/document/safety_argument.md
+++ b/document/safety_argument.md
@@ -1,0 +1,20 @@
+# Safety Argument
+## Why there are so many `unsafe` in SDB
+SDB has 2 design goals:
+1. Scanning the Ruby stack without GVL
+2. Building a non-blocking Ruby stack profiler
+
+A stack profiler is a tool for observability that should not impact applications. However, most Ruby stack profilers need GVL when scanning the Ruby stack, which reduces application performance. For example, a stack profiler may increase latency by 10% for a Rails request at a 1ms scanning interval. Many tools increase the scanning interval to reduce this impact; for instance, the Datadog Ruby Agent uses a 10ms scanning interval, which results in less accurate profiling results and can't detect certain performance issues.
+
+Thus, I believe the first design goal is necessary for a Ruby stack profiler.
+
+Achieving the first design goal could solve 90% or even 99% of performance issues. However, if we do not use synchronization primitives carefully, it can still block Ruby applications in certain situations. Compared to the first design goal, the second one is less impactful but more challenging and interesting.
+
+Because of these design goals, the Rust safety mechanism is not enough. Additionally, it seems that there is no good answer on how to use safe code when using Rust in other systems. For example, in Rust-for-Linux, comments are needed to reason about the safety of unsafe blocks[1]. Magnus[2] also depends on many `unsafe` code blocks and restricts usage, such as not allowing passing Ruby objects to the heap in Rust.
+
+## Scanning the Ruby Stack without the GVL
+## Trace-id Hash Table
+
+## References
+1. An Empirical Study of Rust-for-Linux: The Success, Dissatisfaction, and Compromise
+2. https://github.com/matsadler/magnus?tab=readme-ov-file#safety

--- a/ext/sdb/src/helpers.rs
+++ b/ext/sdb/src/helpers.rs
@@ -26,11 +26,6 @@ pub fn ptr_to_struct<T>(ptr: *mut c_void) -> &'static mut T {
     unsafe { &mut *(ptr as *mut T) }
 }
 
-#[inline]
-pub fn arvg_to_ptr(val: &[VALUE]) -> *const VALUE {
-    val as *const [VALUE] as *const VALUE
-}
-
 pub(crate) unsafe extern "C" fn rb_first_lineno_from_iseq_addr(
     _module: VALUE,
     iseq_addr: VALUE,

--- a/ext/sdb/src/stack_scanner.rs
+++ b/ext/sdb/src/stack_scanner.rs
@@ -1,8 +1,7 @@
 use crate::helpers::*;
 use crate::iseq_logger::*;
 use crate::trace_id::*;
-use std::sync::atomic::{AtomicU64, Ordering};
-
+use std::sync::atomic::AtomicU64;
 
 use chrono::Utc;
 use libc::c_void;
@@ -13,7 +12,6 @@ use rbspy_ruby_structs::ruby_3_1_5::{rb_control_frame_struct, rb_iseq_struct, rb
 
 use std::collections::HashMap;
 use std::slice;
-use std::sync::atomic;
 use std::time::Duration;
 use std::{ptr, thread};
 
@@ -61,9 +59,7 @@ unsafe extern "C" fn record_thread_frames(
 ) {
     let slice = get_control_frame_slice(thread_val);
 
-    // for reading the newest value of trace_id
-    atomic::fence(atomic::Ordering::Acquire);
-    let trace_id = trace_table.get(&thread_val).map(|atomic| atomic.load(Ordering::Acquire)).unwrap_or(0);
+    let trace_id = get_trace_id(trace_table, thread_val);
 
     let ts = Utc::now().timestamp_micros();
 

--- a/ext/sdb/src/trace_id.rs
+++ b/ext/sdb/src/trace_id.rs
@@ -39,9 +39,12 @@ pub fn get_trace_id_table() -> &'static mut HashMap<u64, AtomicU64> {
 #[inline]
 pub(crate) unsafe extern "C" fn set_trace_id(thread: VALUE, trace_id: u64) -> bool {
     let trace_table = get_trace_id_table();
-    let trace_id_atomic = AtomicU64::new(trace_id);
+    let thread_id = thread as u64;
 
-    trace_table.insert(thread as u64, trace_id_atomic);
+    trace_table
+        .entry(thread_id)
+        .or_insert_with(|| AtomicU64::new(trace_id))
+        .store(trace_id, Ordering::Release);
 
     true
 }

--- a/ext/sdb/src/trace_id.rs
+++ b/ext/sdb/src/trace_id.rs
@@ -1,9 +1,9 @@
 use rb_sys::{rb_num2ulong, Qfalse, Qtrue, VALUE};
 use std::collections::HashMap;
 use std::ptr;
-use std::sync::atomic;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-static mut TRACE_TABLE: *mut HashMap<u64, u64> = ptr::null_mut();
+static mut TRACE_TABLE: *mut HashMap<u64, AtomicU64> = ptr::null_mut();
 
 fn init_trace_id_table() {
     unsafe {
@@ -20,13 +20,13 @@ fn init_trace_id_table() {
 // Only during rehashing, it needs to avoid all reads at the same time.
 
 // When the Ruby VM creates a new thread, SDB inserts a dummy value into the trace-id table.
-// At this moment, it already acquired the THREADS_TO_SCAN_LOCK, which blocks the scanner thread -- the only reader(see rb_add_thread_to_scan method).
+// At this moment, it already acquired the THREADS_TO_SCAN_LOCK, which blocks the scanner thread -- the only reader (see rb_add_thread_to_scan method).
 // This guarantees that no reader is accessing this table during rehashing.
 
 // Additionally, when SDB needs to read this, it uses a memory barrier for getting the newest value.
 // Therefore, I believe this implementation is safe even though it has a lot of "unsafe" code. Yes, it is tricky.
 #[inline]
-pub fn get_trace_id_table() -> &'static mut HashMap<u64, u64> {
+pub fn get_trace_id_table() -> &'static mut HashMap<u64, AtomicU64> {
     unsafe {
         if TRACE_TABLE.is_null() {
             init_trace_id_table();
@@ -39,9 +39,9 @@ pub fn get_trace_id_table() -> &'static mut HashMap<u64, u64> {
 #[inline]
 pub(crate) unsafe extern "C" fn set_trace_id(thread: VALUE, trace_id: u64) -> bool {
     let trace_table = get_trace_id_table();
+    let trace_id_atomic = AtomicU64::new(trace_id);
 
-    trace_table.insert(thread, trace_id);
-    atomic::fence(atomic::Ordering::Release);
+    trace_table.insert(thread as u64, trace_id_atomic);
 
     true
 }

--- a/ext/sdb/src/trace_id.rs
+++ b/ext/sdb/src/trace_id.rs
@@ -1,6 +1,7 @@
 use rb_sys::{rb_num2ulong, Qfalse, Qtrue, VALUE};
 use std::collections::HashMap;
 use std::ptr;
+use std::sync::atomic;
 
 static mut TRACE_TABLE: *mut HashMap<u64, u64> = ptr::null_mut();
 
@@ -40,6 +41,7 @@ pub(crate) unsafe extern "C" fn set_trace_id(thread: VALUE, trace_id: u64) -> bo
     let trace_table = get_trace_id_table();
 
     trace_table.insert(thread, trace_id);
+    atomic::fence(atomic::Ordering::Release);
 
     true
 }


### PR DESCRIPTION
1. use atomic variable and memory order for trace-id value
2. added doc about the safety of SDB