### PR TITLE
feat: handle gc compact

### DIFF
--- a/ext/sdb/src/iseq_logger.rs
+++ b/ext/sdb/src/iseq_logger.rs
@@ -1,26 +1,17 @@
-use crate::logger::*;
-
-use fast_log::Logger;
-use log::Log;
-
 const ISEQS_BUFFER_SIZE: usize = 100_000;
 
-pub struct IseqLogger<'a> {
+pub struct IseqLogger {
     buffer: [u64; ISEQS_BUFFER_SIZE],
     buffer_size: usize,
     buffer_index: usize,
-    logger: &'a Logger,
 }
 
-impl<'a> IseqLogger<'a> {
+impl IseqLogger {
     pub fn new() -> Self {
-        let logger = init_logger();
-
         IseqLogger {
             buffer: [0; ISEQS_BUFFER_SIZE],
             buffer_size: ISEQS_BUFFER_SIZE,
             buffer_index: 0,
-            logger: logger,
         }
     }
 
@@ -44,7 +35,6 @@ impl<'a> IseqLogger<'a> {
     pub fn flush(&mut self) {
         log::info!("[stack_frames][{:?}]", &self.buffer[..self.buffer_index]);
         self.buffer_index = 0;
-
-        self.logger.flush();
+        log::logger().flush();
     }
 }

--- a/ext/sdb/src/lib.rs
+++ b/ext/sdb/src/lib.rs
@@ -80,28 +80,6 @@ extern "C" fn Init_sdb() {
         >(rb_pull);
         rb_define_singleton_method(module, "pull\0".as_ptr() as _, Some(pull_callback), 2);
 
-        let delete_inactive_thread_callback = std::mem::transmute::<
-            unsafe extern "C" fn(VALUE, VALUE, VALUE) -> VALUE,
-            unsafe extern "C" fn() -> VALUE,
-        >(rb_delete_inactive_thread);
-        rb_define_singleton_method(
-            module,
-            "delete_inactive_thread\0".as_ptr() as _,
-            Some(delete_inactive_thread_callback),
-            2,
-        );
-
-        let rb_add_thread_to_scan_callback = std::mem::transmute::<
-            unsafe extern "C" fn(VALUE, VALUE, VALUE) -> VALUE,
-            unsafe extern "C" fn() -> VALUE,
-        >(rb_add_thread_to_scan);
-        rb_define_singleton_method(
-            module,
-            "add_thread_to_scan\0".as_ptr() as _,
-            Some(rb_add_thread_to_scan_callback),
-            2,
-        );
-
         let set_trace_id_callback = std::mem::transmute::<
             unsafe extern "C" fn(VALUE, VALUE, VALUE) -> VALUE,
             unsafe extern "C" fn() -> VALUE,

--- a/ext/sdb/src/lib.rs
+++ b/ext/sdb/src/lib.rs
@@ -20,28 +20,40 @@ use trace_id::*;
 use std::os::raw::c_void;
 
 use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
+use lazy_static::lazy_static;
 
+lazy_static! {
+    static ref SDB_MODULE: u64 = unsafe {
+        rb_define_module("Sdb\0".as_ptr() as *const c_char) as u64
+    };
+}
 extern "C" fn gc_enter_callback(_trace_point: VALUE, _data: *mut c_void) {
     // Print the current thread ID
     let thread_id = thread::current().id();
-    println!("gc enter - current thread ID: {:?}", thread_id);
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards");
+    let nanos = now.as_nanos();
+    println!("[gc-hook][gc enter] - current thread ID: {:?}, time: {} ns", thread_id, nanos);
+    disable_scanner();
 
     // Try to acquire the lock
-    if let Some(lock) = THREADS_TO_SCAN_LOCK.try_lock() {
-        println!("Lock acquired");
-        disable_scanner();
-        drop(lock); // Explicitly drop the lock
-    } else {
-        println!("Failed to acquire lock !!!!!!");
-        disable_scanner(); // Still disable scanner even if lock acquisition fails
-    }
+    // if let Some(lock) = THREADS_TO_SCAN_LOCK.try_lock() {
+    //     println!("Lock acquired");
+    //     disable_scanner();
+    //     drop(lock); // Explicitly drop the lock
+    // } else {
+    //     println!("Failed to acquire lock !!!!!!");
+    //     disable_scanner(); // Still disable scanner even if lock acquisition fails
+    // }
 }
 
 unsafe extern "C" fn gc_exist_callback(_trace_point: VALUE, _data: *mut c_void) {
-    print!("gc exist\n");
-    let sdb_module: u64 = rb_define_module("Sdb\0".as_ptr() as *const c_char);
-    // no need call enable_scanner, because the scanner will be enabled in the next loop of the puller thread
-    call_method(sdb_module, "start_to_pull", 0, &[]);
+    let thread_id = thread::current().id();
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards");
+    let nanos = now.as_nanos();
+    println!("[gc-hook][gc exist] - current thread ID: {:?}, time: {} ns", thread_id, nanos);
+
+    call_method(*SDB_MODULE as VALUE, "start_to_pull", 0, &[]);
 }
 
 pub(crate) unsafe extern "C" fn setup_gc_hook(_module: VALUE) -> VALUE {

--- a/ext/sdb/src/lib.rs
+++ b/ext/sdb/src/lib.rs
@@ -13,9 +13,9 @@ use rb_sys::{
 
 use gvl::*;
 use helpers::*;
+use logger::*;
 use stack_scanner::*;
 use trace_id::*;
-use logger::*;
 
 use std::os::raw::c_void;
 

--- a/ext/sdb/src/lib.rs
+++ b/ext/sdb/src/lib.rs
@@ -53,6 +53,7 @@ unsafe extern "C" fn gc_exist_callback(_trace_point: VALUE, _data: *mut c_void) 
     let nanos = now.as_nanos();
     println!("[gc-hook][gc exist] - current thread ID: {:?}, time: {} ns", thread_id, nanos);
 
+    enable_scanner();
     call_method(*SDB_MODULE as VALUE, "start_to_pull", 0, &[]);
 }
 

--- a/ext/sdb/src/lib.rs
+++ b/ext/sdb/src/lib.rs
@@ -56,7 +56,12 @@ unsafe extern "C" fn gc_exist_callback(_trace_point: VALUE, _data: *mut c_void) 
         thread_id, nanos
     );
 
-    enable_scanner();
+    // start_to_pull triggers puller thread sstart_to_pullignal,
+    // the puller thread handles the signal only after it finishes its scanning.
+    // As the enable_scanner is called in the puller thread after the condition variable is signaled,
+    // if before it calls enable_scanner, the gc thread acquires the lock and disables the scanner,
+    // it lost one stop event ....
+    // Add a generation could fix this ...
     call_method(*SDB_MODULE as VALUE, "start_to_pull", 0, &[]);
 }
 

--- a/ext/sdb/src/stack_scanner.rs
+++ b/ext/sdb/src/stack_scanner.rs
@@ -193,35 +193,6 @@ pub(crate) unsafe extern "C" fn rb_pull(
     Qtrue as VALUE
 }
 
-pub(crate) unsafe extern "C" fn rb_delete_inactive_thread(
-    _module: VALUE,
-    threads_to_scan: VALUE,
-    thread: VALUE,
-) -> VALUE {
-    println!("rb_delete_inactive_thread");
-    let lock = THREADS_TO_SCAN_LOCK.lock();
-    call_method(threads_to_scan, "delete", 1, &[thread]);
-    drop(lock);
-
-    Qtrue as VALUE
-}
-
-pub(crate) unsafe extern "C" fn rb_add_thread_to_scan(
-    _module: VALUE,
-    threads_to_scan: VALUE,
-    thread: VALUE,
-) -> VALUE {
-    println!("rb_add_thread_to_scan");
-    let lock = THREADS_TO_SCAN_LOCK.lock();
-    // THREADS_TO_SCAN_LOCK guarantees mutually exclusive access, which blocks the scanner thread.
-    // As the trace-id table doesn't have a lock, inserting a dummy value to avoid hash reallocation.
-    set_trace_id(thread, 0);
-    call_method(threads_to_scan, "push", 1, &[thread]);
-    drop(lock);
-
-    Qtrue as VALUE
-}
-
 // for testing
 pub(crate) unsafe extern "C" fn rb_get_on_stack_func_addresses(
     _module: VALUE,

--- a/ext/sdb/src/stack_scanner.rs
+++ b/ext/sdb/src/stack_scanner.rs
@@ -98,7 +98,7 @@ unsafe extern "C" fn record_thread_frames(
         None => {
             println!("no frames for thread: {:?}", thread_val);
             return false;
-        },
+        }
     };
 
     let trace_id = get_trace_id(trace_table, thread_val);
@@ -193,7 +193,7 @@ unsafe extern "C" fn do_pull(data: *mut c_void) -> *mut c_void {
         }
 
         if data.sleep_millis != 0 {
-            thread::sleep(Duration::from_millis(data.sleep_millis as u64));            
+            thread::sleep(Duration::from_millis(data.sleep_millis as u64));
         }
     }
     // ptr::null_mut()

--- a/ext/sdb/src/stack_scanner.rs
+++ b/ext/sdb/src/stack_scanner.rs
@@ -169,7 +169,6 @@ unsafe extern "C" fn do_pull(data: *mut c_void) -> *mut c_void {
         }
 
         let lock = THREADS_TO_SCAN_LOCK.lock();
-        println!("do_pull THREADS_TO_SCAN_LOCK acquired");
 
         let threads_count = RARRAY_LEN(data.threads_to_scan) as isize;
         let mut i: isize = 0;
@@ -202,6 +201,9 @@ pub(crate) unsafe extern "C" fn rb_pull(
     threads_to_scan: VALUE,
     sleep_seconds: VALUE,
 ) -> VALUE {
+    let thread_id = thread::current().id();
+    println!("rb_pull - current thread ID: {:?}", thread_id);
+
     let argv: &[VALUE; 0] = &[];
     let current_thread = call_method(module, "current_thread", 0, argv);
 

--- a/ext/sdb/src/stack_scanner.rs
+++ b/ext/sdb/src/stack_scanner.rs
@@ -8,7 +8,7 @@ use libc::c_void;
 use rb_sys::{
     rb_int2inum, rb_num2dbl, rb_thread_call_without_gvl, Qnil, Qtrue, RTypedData, RARRAY_LEN, VALUE,
 };
-use rbspy_ruby_structs::ruby_3_1_5::{rb_control_frame_struct, rb_iseq_struct, rb_thread_t};
+use rbspy_ruby_structs::ruby_3_1_5::{rb_control_frame_struct, rb_thread_t};
 use sysinfo::System;
 
 use std::collections::HashMap;
@@ -49,12 +49,6 @@ struct PullData {
     current_thread: VALUE,
     threads_to_scan: VALUE,
     sleep_millis: u32,
-}
-
-#[inline]
-unsafe fn is_valid_thread(thread_val: VALUE) -> bool {
-    // Check if the value is a T_THREAD type
-    (thread_val & 0x1f) == 0x7
 }
 
 #[inline]
@@ -163,17 +157,10 @@ unsafe extern "C" fn do_pull(data: *mut c_void) -> *mut c_void {
     let data: &mut PullData = ptr_to_struct(data);
     let trace_table = get_trace_id_table();
 
-    let mut j = 0;
     loop {
         if should_stop_scanner() {
             iseq_logger.flush();
             return ptr::null_mut();
-        }
-
-        j += 1;
-
-        if j % 10 == 0 {
-            println!("looping: {}", j);
         }
 
         let lock = THREADS_TO_SCAN_LOCK.lock();

--- a/ext/sdb/src/stack_scanner.rs
+++ b/ext/sdb/src/stack_scanner.rs
@@ -101,7 +101,10 @@ pub(crate) fn uptime_and_clock_time() -> (u64, i64) {
     loop {
         if System::uptime() - uptime >= 1.0 as u64 {
             // covert to micros for uptime
-            return ((uptime + 1.0 as u64) * 1_000_000, Utc::now().timestamp_micros());
+            return (
+                (uptime + 1.0 as u64) * 1_000_000,
+                Utc::now().timestamp_micros(),
+            );
         }
     }
 }

--- a/lib/sdb.rb
+++ b/lib/sdb.rb
@@ -50,6 +50,7 @@ module Sdb
           @start_to_pull = false
           @puller_mutex.unlock
 
+          self.enable_scanner
           self.pull(@threads_to_scan, @sleep_interval)
         }
       end

--- a/lib/sdb.rb
+++ b/lib/sdb.rb
@@ -46,7 +46,9 @@ module Sdb
         loop {
           @puller_mutex.lock
           until @start_to_pull
+            puts "before wait"
             @puller_cond.wait(@puller_mutex)
+             puts "after wait"
           end
 
           if @puller_mutex.try_lock
@@ -58,6 +60,7 @@ module Sdb
 
           puts "SDB will scan @threads_to_scan=#{@threads_to_scan} with sleep_interval=#{@sleep_interval}"
           self.pull(@threads_to_scan, @sleep_interval)
+          puts "one pull done!!!"
           self.enable_scanner
         }
       end

--- a/lib/sdb.rb
+++ b/lib/sdb.rb
@@ -42,13 +42,10 @@ module Sdb
       puts "@threads_to_scan=#{@threads_to_scan}"
 
       @puller_thread = Thread.new do
-        puts "[puller-thread] started"
         loop {
           @puller_mutex.lock
           until @start_to_pull
-            puts "before wait"
             @puller_cond.wait(@puller_mutex)
-            puts "after wait"
           end
 
           if @puller_mutex.try_lock
@@ -58,9 +55,7 @@ module Sdb
           @start_to_pull = false
           @puller_mutex.unlock
 
-          puts "[puller-thread] SDB will scan @threads_to_scan=#{@threads_to_scan} with sleep_interval=#{@sleep_interval}"
           self.pull(@threads_to_scan, @sleep_interval)
-          puts "[puller-thread] one pull done!!!"
         }
       end
     end
@@ -82,7 +77,6 @@ module Sdb
       @filter = filter
       @sleep_interval = sleep_interval
 
-      # puts "SDB will scan @threads_to_scan=#{@threads_to_scan} with sleep_interval=#{@sleep_interval}"
       @puller_mutex.synchronize do
         @start_to_pull = true
         @puller_cond.signal
@@ -92,7 +86,6 @@ module Sdb
     end
 
     def start_to_pull
-      # puts "start_to_pull ........."
       @puller_mutex.synchronize do
         @start_to_pull = true
         @puller_cond.signal

--- a/lib/sdb.rb
+++ b/lib/sdb.rb
@@ -26,6 +26,7 @@ module Sdb
   class << self
     def init_once
       return true if @initialized
+      raise "Unsupported ruby version: #{RUBY_VERSION}" if RUBY_VERSION != '3.1.5'
 
       self.init_logger
       self.setup_gc_hook


### PR DESCRIPTION
Here’s the corrected version with improved clarity, grammar, and technical precision:  

---

When the Ruby VM's GC starts, it should stop the scanner thread, as it may move thread objects to a different location.  
After the GC finishes, we restart the scanner, which fetches the updated thread list.  

## **Correctness**  

There are two threads: the GC thread and the scanner thread. (Although different threads can trigger GC, due to the Global VM Lock (GVL), only one thread can perform GC at a time. In this context, we can consider a single GC thread.)  

A conditional variable is used to signal the scanner thread to start scanning.  

Suppose the scanner is traversing the stacks when the GC start hook updates an atomic variable, instructing the scanner to stop. Once GC completes, the GC end hook triggers the conditional variable to resume scanning.  

I will prove that the sequence of events must be:  
1. The stop variable is set to `true`.  
2. The scanner stops scanning.  
3. The stop variable is set to `false`.  
4. The scanner starts scanning using the updated thread list.  

The key lies in how the scanner thread processes signals and scanning. It scans the stacks, and once the scan is complete, it checks the conditional variable. When it resumes, it sets the stop variable back to `false`. Since the scanner thread executes commands sequentially, it must complete the current scan before checking the conditional variable. Therefore, the scanner can be reliably stopped using the stop variable.  