### PR TITLE
feat: opt

### DIFF
--- a/document/safety_argument.md
+++ b/document/safety_argument.md
@@ -24,7 +24,7 @@ To use a hash table safely, we need to consider:
 1. Before resizing a hash table, we should have exclusive access.
 2. When querying a hash table, we should see the most recent write.
 
-When creating a new Ruby thread, a mutex (`THREADS_TO_SCAN_LOCK`) is acquired for updating the threads list. This mutex is used for guarantee exclusive access when updating the threads list, while this lock is held, the scanner is blocked too. During this time, a dummy trace-id is inserted for the thread into the table. Similarly, when a Ruby thread is being reclaimed, the lock is acquired, and the thread is deleted from the table. Hash resizing can only happen when a new key is added or a key is deleted. Since the lock is held during these operations, the scanner thread does not read the table, fulfilling the first consideration.
+When creating a new Ruby thread, a mutex (`STACK_SCANNER`) is acquired for updating the threads list. This mutex is used for guarantee exclusive access when updating the threads list, while this lock is held, the scanner is blocked too. During this time, a dummy trace-id is inserted for the thread into the table. Similarly, when a Ruby thread is being reclaimed, the lock is acquired, and the thread is deleted from the table. Hash resizing can only happen when a new key is added or a key is deleted. Since the lock is held during these operations, the scanner thread does not read the table, fulfilling the first consideration.
 
 For the second consideration, SDB uses atomic variables for the hash table's values with memory ordering (release order when updating and acquire order when reading).
 

--- a/examples/benchmark.rb
+++ b/examples/benchmark.rb
@@ -18,7 +18,7 @@ end
 # sleep_interval = 0.00_001
 # sleep_interval = 0.000_001
 sleep_interval = 0.0000_0_01
-Sdb.scan_threads([Thread.current], sleep_interval)
+Sdb.scan_all_threads(sleep_interval)
 test(150, 500_000_000)
 
 

--- a/ext/sdb/src/helpers.rs
+++ b/ext/sdb/src/helpers.rs
@@ -16,16 +16,6 @@ pub(crate) fn call_method(receiver: VALUE, method: &str, argc: c_int, argv: &[VA
     unsafe { rb_funcallv(receiver, id, argc, argv as *const [VALUE] as *const VALUE) }
 }
 
-#[inline]
-pub(crate) fn struct_to_ptr<T>(data: &mut T) -> *mut c_void {
-    data as *mut T as *mut c_void
-}
-
-#[inline]
-pub(crate) fn ptr_to_struct<T>(ptr: *mut c_void) -> &'static mut T {
-    unsafe { &mut *(ptr as *mut T) }
-}
-
 pub(crate) unsafe extern "C" fn rb_first_lineno_from_iseq_addr(
     _module: VALUE,
     iseq_addr: VALUE,

--- a/ext/sdb/src/iseq_logger.rs
+++ b/ext/sdb/src/iseq_logger.rs
@@ -1,4 +1,4 @@
-const ISEQS_BUFFER_SIZE: usize = 100_000;
+const ISEQS_BUFFER_SIZE: usize = 10_000;
 
 pub struct IseqLogger {
     buffer: [u64; ISEQS_BUFFER_SIZE],

--- a/ext/sdb/src/iseq_logger.rs
+++ b/ext/sdb/src/iseq_logger.rs
@@ -1,4 +1,4 @@
-const ISEQS_BUFFER_SIZE: usize = 10_000;
+const ISEQS_BUFFER_SIZE: usize = 100_000;
 
 pub struct IseqLogger {
     buffer: [u64; ISEQS_BUFFER_SIZE],

--- a/ext/sdb/src/iseq_logger.rs
+++ b/ext/sdb/src/iseq_logger.rs
@@ -32,6 +32,7 @@ impl IseqLogger {
         self.push(u64::MAX);
     }
 
+    #[inline]
     pub fn flush(&mut self) {
         log::info!("[stack_frames][{:?}]", &self.buffer[..self.buffer_index]);
         self.buffer_index = 0;

--- a/ext/sdb/src/lib.rs
+++ b/ext/sdb/src/lib.rs
@@ -30,7 +30,7 @@ extern "C" fn gc_enter_callback(_trace_point: VALUE, _data: *mut c_void) {
     // then the lock is acquired by the gc thread, and the gc thread will disable the scanner.
     // THREADS_TO_SCAN_LOCK.lock();
     THREADS_TO_SCAN_LOCK.lock();
-    log::debug!("[gc-hook][enter] stop scanner");
+    // log::debug!("[gc-hook][enter] stop scanner");
     // log::logger().flush();
     let (lock, _) = &*START_TO_PULL_COND_VAR;
     let mut start = lock.lock().unwrap();
@@ -47,11 +47,11 @@ unsafe extern "C" fn gc_exist_callback(_trace_point: VALUE, _data: *mut c_void) 
     // Add a generation could fix this ...
 
     THREADS_TO_SCAN_LOCK.lock();
-    log::debug!("[gc-hook][exist]");
+    // log::debug!("[gc-hook][exist]");
     // log::logger().flush();
 
     if is_stopped() {
-        log::debug!("[gc-hook][exist] restart stack scanner");
+        // log::debug!("[gc-hook][exist] restart stack scanner");
         let (lock, cvar) = &*START_TO_PULL_COND_VAR;
         let mut start = lock.lock().unwrap();
         enable_scanner();

--- a/ext/sdb/src/lib.rs
+++ b/ext/sdb/src/lib.rs
@@ -125,16 +125,5 @@ extern "C" fn Init_sdb() {
             Some(rb_log_uptime_and_clock_time_callback),
             0,
         );
-
-        let rb_set_threads_to_scan_callback = std::mem::transmute::<
-            unsafe extern "C" fn(VALUE, VALUE) -> VALUE,
-            unsafe extern "C" fn() -> VALUE,
-        >(rb_set_threads_to_scan);
-        rb_define_singleton_method(
-            module,
-            "set_threads_to_scan\0".as_ptr() as _,
-            Some(rb_set_threads_to_scan_callback),
-            1,
-        );
     }
 }

--- a/ext/sdb/src/lib.rs
+++ b/ext/sdb/src/lib.rs
@@ -33,10 +33,10 @@ extern "C" fn Init_sdb() {
         let module = rb_define_module("Sdb\0".as_ptr() as *const c_char);
 
         let pull_callback = std::mem::transmute::<
-            unsafe extern "C" fn(VALUE, VALUE, VALUE) -> VALUE,
+            unsafe extern "C" fn(VALUE, VALUE) -> VALUE,
             unsafe extern "C" fn() -> VALUE,
         >(rb_pull);
-        rb_define_singleton_method(module, "pull\0".as_ptr() as _, Some(pull_callback), 2);
+        rb_define_singleton_method(module, "pull\0".as_ptr() as _, Some(pull_callback), 1);
 
         let set_trace_id_callback = std::mem::transmute::<
             unsafe extern "C" fn(VALUE, VALUE, VALUE) -> VALUE,
@@ -124,6 +124,17 @@ extern "C" fn Init_sdb() {
             "log_uptime_and_clock_time\0".as_ptr() as _,
             Some(rb_log_uptime_and_clock_time_callback),
             0,
+        );
+
+        let rb_update_threads_to_scan_callback = std::mem::transmute::<
+            unsafe extern "C" fn(VALUE, VALUE) -> VALUE,
+            unsafe extern "C" fn() -> VALUE,
+        >(rb_update_threads_to_scan);
+        rb_define_singleton_method(
+            module,
+            "update_threads_to_scan\0".as_ptr() as _,
+            Some(rb_update_threads_to_scan_callback),
+            1,
         );
     }
 }

--- a/ext/sdb/src/lib.rs
+++ b/ext/sdb/src/lib.rs
@@ -6,16 +6,12 @@ mod stack_scanner;
 mod trace_id;
 
 use libc::c_char;
-use rb_sys::{
-    rb_cObject, rb_define_alloc_func, rb_define_class, rb_define_method, rb_define_module,
-    rb_define_singleton_method, rb_tracepoint_enable, rb_tracepoint_new, Qnil, VALUE,
-};
+use rb_sys::{rb_define_module, rb_define_singleton_method, Qnil, VALUE};
 
 use gvl::*;
 use helpers::*;
 use logger::*;
 use stack_scanner::*;
-use std::os::raw::c_void;
 use trace_id::*;
 
 use lazy_static::lazy_static;
@@ -23,64 +19,6 @@ use lazy_static::lazy_static;
 lazy_static! {
     static ref SDB_MODULE: u64 =
         unsafe { rb_define_module("Sdb\0".as_ptr() as *const c_char) as u64 };
-}
-
-extern "C" fn gc_enter_callback(_trace_point: VALUE, _data: *mut c_void) {
-    // when the scanner thread has finished one thread scans, it releases lock,
-    // then the lock is acquired by the gc thread, and the gc thread will disable the scanner.
-    let mut stack_scanner = STACK_SCANNER.lock();
-
-    // log::debug!("[gc-hook][enter] stop scanner");
-    // log::logger().flush();
-    let (lock, _) = &*START_TO_PULL_COND_VAR;
-    let mut start = lock.lock().unwrap();
-    *start = false;
-
-    stack_scanner.stop();
-}
-
-unsafe extern "C" fn gc_exist_callback(_trace_point: VALUE, _data: *mut c_void) {
-    // start_to_pull triggers puller thread sstart_to_pullignal,
-    // the puller thread handles the signal only after it finishes its scanning.
-    // As the enable_scanner is called in the puller thread after the condition variable is signaled,
-    // if before it calls enable_scanner, the gc thread acquires the lock and disables the scanner,
-    // it lost one stop event ....
-    // Add a generation could fix this ...
-
-    let mut stack_scanner = STACK_SCANNER.lock();
-    // log::debug!("[gc-hook][exist]");
-    // log::logger().flush();
-
-    if stack_scanner.is_stopped() {
-        // log::debug!("[gc-hook][exist] restart stack scanner");
-        let (lock, cvar) = &*START_TO_PULL_COND_VAR;
-        let mut start = lock.lock().unwrap();
-        stack_scanner.start();
-        *start = true;
-        cvar.notify_one();
-    }
-}
-
-pub(crate) unsafe extern "C" fn setup_gc_hook(_module: VALUE) -> VALUE {
-    unsafe {
-        let tp = rb_tracepoint_new(
-            0,
-            rb_sys::RUBY_INTERNAL_EVENT_GC_ENTER,
-            Some(gc_enter_callback),
-            std::ptr::null_mut(),
-        );
-        rb_tracepoint_enable(tp);
-
-        let tp_exist = rb_tracepoint_new(
-            0,
-            rb_sys::RUBY_INTERNAL_EVENT_GC_EXIT,
-            Some(gc_exist_callback),
-            std::ptr::null_mut(),
-        );
-        rb_tracepoint_enable(tp_exist);
-    }
-
-    return Qnil as VALUE;
 }
 
 pub(crate) unsafe extern "C" fn rb_init_logger(_module: VALUE) -> VALUE {
@@ -92,21 +30,6 @@ pub(crate) unsafe extern "C" fn rb_init_logger(_module: VALUE) -> VALUE {
 #[no_mangle]
 extern "C" fn Init_sdb() {
     unsafe {
-        let stack_scanner_class =
-            rb_define_class("StackScanner\0".as_ptr() as *const c_char, rb_cObject);
-        rb_define_alloc_func(stack_scanner_class, Some(rb_stack_scanner_alloc));
-
-        let stacn_scanner_initialize_callback = std::mem::transmute::<
-            unsafe extern "C" fn(VALUE) -> VALUE,
-            unsafe extern "C" fn() -> VALUE,
-        >(rb_stack_scanner_initialize);
-        rb_define_method(
-            stack_scanner_class,
-            "initialize\0".as_ptr() as _,
-            Some(stacn_scanner_initialize_callback),
-            0,
-        );
-
         let module = rb_define_module("Sdb\0".as_ptr() as *const c_char);
 
         let pull_callback = std::mem::transmute::<
@@ -212,17 +135,6 @@ extern "C" fn Init_sdb() {
             "set_threads_to_scan\0".as_ptr() as _,
             Some(rb_set_threads_to_scan_callback),
             1,
-        );
-
-        let setup_gc_hook_callback = std::mem::transmute::<
-            unsafe extern "C" fn(VALUE) -> VALUE,
-            unsafe extern "C" fn() -> VALUE,
-        >(setup_gc_hook);
-        rb_define_singleton_method(
-            module,
-            "setup_gc_hook\0".as_ptr() as _,
-            Some(setup_gc_hook_callback),
-            0,
         );
     }
 }

--- a/ext/sdb/src/stack_scanner.rs
+++ b/ext/sdb/src/stack_scanner.rs
@@ -28,6 +28,8 @@ use std::sync;
 use std::sync::Condvar;
 
 const ONE_MILLISECOND_NS: u64 = 1_000_000; // 1ms in nanoseconds
+const CONTROL_FRAME_STRUCT_SIZE: usize = std::mem::size_of::<rb_control_frame_struct>();
+
 pub struct RbDataType(rb_data_type_t);
 
 pub struct StackScanner {
@@ -45,14 +47,17 @@ impl StackScanner {
         }
     }
 
+    #[inline]
     pub fn stop(&mut self) {
         self.should_stop = true;
     }
 
+    #[inline]
     pub fn start(&mut self) {
         self.should_stop = false;
     }
 
+    #[inline]
     pub fn is_stopped(&self) -> bool {
         self.should_stop
     }
@@ -148,7 +153,7 @@ unsafe fn get_control_frame_slice(thread_val: VALUE) -> &'static [rb_control_fra
     let stack_base = ec.vm_stack.add(ec.vm_stack_size);
     let diff = (stack_base as usize) - (ec.cfp as usize);
     // todo: pass rb_control_frame_struct size in
-    let len = diff / std::mem::size_of::<rb_control_frame_struct>();
+    let len = diff / CONTROL_FRAME_STRUCT_SIZE;
 
     slice::from_raw_parts(ec.cfp, len)
 }

--- a/ext/sdb/src/stack_scanner.rs
+++ b/ext/sdb/src/stack_scanner.rs
@@ -124,7 +124,6 @@ pub(crate) fn is_stopped() -> bool {
 
 struct PullData {
     current_thread: VALUE,
-    threads_to_scan: VALUE,
     sleep_nanos: u64,
     threads: Vec<VALUE>,
 }
@@ -208,11 +207,10 @@ unsafe extern "C" fn do_loop(data: &mut PullData, iseq_logger: &mut IseqLogger) 
         let lock = THREADS_TO_SCAN_LOCK.lock();
 
         if should_stop_scanner() {
-            log::debug!(
-                "[scanner][main] stop scanner thread_to_scan={:?}",
-                data.threads_to_scan
-            );
-            iseq_logger.flush();
+            // log::debug!(
+            //     "[scanner][main] stop scanner thread_to_scan={:?}",
+            //     data.threads_to_scan
+            // );
 
             // stop once for waiting next turn
             return ptr::null_mut();
@@ -278,7 +276,6 @@ pub(crate) unsafe extern "C" fn rb_pull(
 
     let mut data = PullData {
         current_thread: current_thread,
-        threads_to_scan,
         sleep_nanos: sleep_nanos,
         threads: vec![],
     };

--- a/ext/sdb/src/stack_scanner.rs
+++ b/ext/sdb/src/stack_scanner.rs
@@ -212,7 +212,11 @@ unsafe extern "C" fn do_loop(data: &mut PullData, iseq_logger: &mut IseqLogger) 
             //     data.threads_to_scan
             // );
 
-            // stop once for waiting next turn
+            // normally, the scanner thread is stopped by the gc thread,
+            // we flush the logs fore reducing the latency impact.
+            iseq_logger.flush();
+
+            // stop once for waiting the next turn
             return ptr::null_mut();
         }
 

--- a/ext/sdb/src/stack_scanner.rs
+++ b/ext/sdb/src/stack_scanner.rs
@@ -145,6 +145,7 @@ unsafe fn get_control_frame_slice(thread_val: VALUE) -> &'static [rb_control_fra
     slice::from_raw_parts(ec.cfp, len)
 }
 
+#[inline]
 unsafe extern "C" fn record_thread_frames(
     thread_val: VALUE,
     trace_table: &HashMap<u64, AtomicU64>,

--- a/ext/sdb/src/stack_scanner.rs
+++ b/ext/sdb/src/stack_scanner.rs
@@ -223,6 +223,11 @@ pub(crate) unsafe extern "C" fn rb_pull(
     );
 
     let sleep_nanos = (rb_num2dbl(sleep_seconds) * 1_000_000_000.0) as u64;
+
+    let mut stack_scanner = STACK_SCANNER.lock();
+    stack_scanner.sleep_nanos = sleep_nanos;
+    drop(stack_scanner);
+
     println!("sleep interval {:?} ns", sleep_nanos / 1000);
 
     // release gvl for avoiding block application's threads

--- a/ext/sdb/src/stack_scanner.rs
+++ b/ext/sdb/src/stack_scanner.rs
@@ -53,7 +53,6 @@ impl StackScanner {
         self.should_stop
     }
 
-
     // GVL must be hold before calling this function
     pub unsafe fn update_threads(&mut self, threads_to_scan: VALUE, current_thread: VALUE) {
         let threads_count = RARRAY_LEN(threads_to_scan) as isize;

--- a/ext/sdb/src/trace_id.rs
+++ b/ext/sdb/src/trace_id.rs
@@ -20,7 +20,7 @@ fn init_trace_id_table() {
 // Only during rehashing, it needs to avoid all reads at the same time.
 
 // When the Ruby VM creates a new thread, SDB inserts a dummy value into the trace-id table.
-// At this moment, it already acquired the THREADS_TO_SCAN_LOCK, which blocks the scanner thread -- the only reader (see rb_add_thread_to_scan method).
+// At this moment, it already acquired the STACK_SCANNER, which blocks the scanner thread -- the only reader (see rb_add_thread_to_scan method).
 // This guarantees that no reader is accessing this table during rehashing.
 
 // Additionally, when SDB needs to read this, it uses a memory barrier for getting the newest value.

--- a/ext/sdb/src/trace_id.rs
+++ b/ext/sdb/src/trace_id.rs
@@ -51,21 +51,23 @@ pub(crate) fn set_trace_id(thread: VALUE, trace_id: u64) -> bool {
 
 // When we use a memory order, do we need to consider a function as unsafe?
 #[inline]
-pub(crate) fn get_trace_id(trace_table: &HashMap<u64, AtomicU64>, thread: VALUE) -> u64 {
-    trace_table
-        .get(&thread)
-        .map(|atomic| atomic.load(Ordering::Acquire))
-        .unwrap_or(0)
+pub(crate) fn get_trace_id(_trace_table: &HashMap<u64, AtomicU64>, _thread: VALUE) -> u64 {
+    // trace_table
+    //     .get(&thread)
+    //     .map(|atomic| atomic.load(Ordering::Acquire))
+    //     .unwrap_or(0)
+    0
 }
 
 pub(crate) unsafe extern "C" fn rb_set_trace_id(
     _module: VALUE,
-    thread: VALUE,
-    trace_id: VALUE,
+    _thread: VALUE,
+    _trace_id: VALUE,
 ) -> VALUE {
-    if set_trace_id(thread, rb_num2ulong(trace_id)) {
-        Qtrue as VALUE
-    } else {
-        Qfalse as VALUE
-    }
+    Qtrue as VALUE
+    // if set_trace_id(thread, rb_num2ulong(trace_id)) {
+    //     Qtrue as VALUE
+    // } else {
+    //     Qfalse as VALUE
+    // }
 }

--- a/ext/sdb/src/trace_id.rs
+++ b/ext/sdb/src/trace_id.rs
@@ -1,7 +1,7 @@
 use rb_sys::{rb_num2ulong, Qfalse, Qtrue, VALUE};
 use std::collections::HashMap;
 use std::ptr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::AtomicU64;
 
 static mut TRACE_TABLE: *mut HashMap<u64, AtomicU64> = ptr::null_mut();
 
@@ -37,14 +37,14 @@ pub(crate) fn get_trace_id_table() -> &'static mut HashMap<u64, AtomicU64> {
 }
 
 #[inline]
-pub(crate) fn set_trace_id(thread: VALUE, trace_id: u64) -> bool {
-    let trace_table = get_trace_id_table();
-    let thread_id = thread as u64;
+pub(crate) fn set_trace_id(_thread: VALUE, _trace_id: u64) -> bool {
+    // let trace_table = get_trace_id_table();
+    // let thread_id = thread as u64;
 
-    trace_table
-        .entry(thread_id)
-        .or_insert_with(|| AtomicU64::new(trace_id))
-        .store(trace_id, Ordering::Release);
+    // trace_table
+    //     .entry(thread_id)
+    //     .or_insert_with(|| AtomicU64::new(trace_id))
+    //     .store(trace_id, Ordering::Release);
 
     true
 }
@@ -61,13 +61,12 @@ pub(crate) fn get_trace_id(_trace_table: &HashMap<u64, AtomicU64>, _thread: VALU
 
 pub(crate) unsafe extern "C" fn rb_set_trace_id(
     _module: VALUE,
-    _thread: VALUE,
-    _trace_id: VALUE,
+    thread: VALUE,
+    trace_id: VALUE,
 ) -> VALUE {
-    Qtrue as VALUE
-    // if set_trace_id(thread, rb_num2ulong(trace_id)) {
-    //     Qtrue as VALUE
-    // } else {
-    //     Qfalse as VALUE
-    // }
+    if set_trace_id(thread, rb_num2ulong(trace_id)) {
+        Qtrue as VALUE
+    } else {
+        Qfalse as VALUE
+    }
 }

--- a/lib/sdb.rb
+++ b/lib/sdb.rb
@@ -35,7 +35,6 @@ module Sdb
 
       puts "@threads_to_scan=#{@threads_to_scan}"
       self.set_threads_to_scan(@threads_to_scan)
-      self.setup_gc_hook
 
       @stack_scanner = StackScanner.new
 

--- a/lib/sdb.rb
+++ b/lib/sdb.rb
@@ -58,11 +58,11 @@ module Sdb
     end
 
     def scan_puma_threads(sleep_interval = 0.001)
-      init_once
-
       scan_threads_helper(sleep_interval) do |thread|
         thread.name&.include?('puma srv tp')
       end
+
+      init_once
     end
 
     def scan_all_threads(sleep_interval = 0.001)
@@ -72,17 +72,20 @@ module Sdb
     end
 
     def thread_created(thread)
+      @active_threads ||= []
       @active_threads << thread
 
-      threads_to_scan = @active_threads.filter(&@filter)
+      threads_to_scan = @active_threads.filter(&@filter).to_a
 
       puts "thread_created: threads_to_scan=#{threads_to_scan}"
       self.update_threads_to_scan(threads_to_scan)
     end
 
     def thread_deleted(thread)
+      @active_threads ||= []
+
       @active_threads.delete(thread)
-      threads_to_scan = @active_threads.filter(&@filter)
+      threads_to_scan = @active_threads.filter(&@filter).to_a
 
       puts "thread_deleted: threads_to_scan=#{threads_to_scan}"
       self.update_threads_to_scan(threads_to_scan)

--- a/symbolizer/symbolizer.c
+++ b/symbolizer/symbolizer.c
@@ -277,18 +277,18 @@ int rb_define_module_return_instrument(struct pt_regs *ctx) {
 // static VALUE gc_move(rb_objspace_t *objspace, VALUE scan, VALUE free, size_t src_slot_size, size_t slot_size);
 int gc_move_instrument(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
-    u64 pid = pid_tgid >> 32;
+    // u64 pid = pid_tgid >> 32;
     u64 tid = pid_tgid & 0xFFFFFFFF;
 
     struct event_t event = {};
-    event.pid = pid;
+    // event.pid = pid;
     event.tid = tid;
     event.ts = bpf_ktime_get_ns();
 
     event.iseq_addr = PT_REGS_PARM2(ctx);
     event.to_addr = PT_REGS_PARM3(ctx);
-    strncpy(event.name, "gc_move", MAX_STR_LENGTH - 1);
-    event.name[MAX_STR_LENGTH - 1] = '\0';
+    // strncpy(event.name, "gc_move", MAX_STR_LENGTH - 1);
+    // event.name[MAX_STR_LENGTH - 1] = '\0';
     event.type = 7;
     events.perf_submit(ctx, &event, sizeof(event));
 


### PR DESCRIPTION
1. Only access the execution context in the stack scanner
2. Remove all GC-related code as the execution context doesn't move
3. Handle threads life cycle